### PR TITLE
Fix link to CUBE CSS article

### DIFF
--- a/docs/lesson/19.md
+++ b/docs/lesson/19.md
@@ -12,7 +12,7 @@ This is exactly how we’ll be using Sass to write our CSS—as an extension of 
 
 ::: tip
 
-Before we dig deep into the front-end, I strongly recommend that you read [my article on CUBE CSS](https://piccalil.lihttps://piccalil.li/blog/cube-css/).
+Before we dig deep into the front-end, I strongly recommend that you read [my article on CUBE CSS](https://piccalil.li/blog/cube-css/).
 
 We will of course cover it well in this course, but understanding why we’re using Sass will be a lot easier when you understand CUBE CSS.
 


### PR DESCRIPTION
It seems the current link is a mesh of two distinct URL, one pointing to the website and one to the actual article.

```diff
-https://piccalil.lihttps://piccalil.li/blog/cube-css/
+https://piccalil.li/blog/cube-css/
```