### PR TITLE
Fix links to CUBE CSS article

### DIFF
--- a/docs/lesson/22.md
+++ b/docs/lesson/22.md
@@ -6,7 +6,7 @@ Right, here we are, in the **final module** of this course. This is actually my 
 
 Of course I enjoy Eleventy, but I’m a designer by trade, so the part where we make stuff look good is naturally going to be the part I enjoy the most.
 
-If you haven’t already: I **strongly recommend** that you [read this post that I wrote on CUBE CSS](https://piccalil.lihttps://piccalil.li/blog/cube-css/).
+If you haven’t already: I **strongly recommend** that you [read this post that I wrote on CUBE CSS](https://piccalil.li/cube-css/).
 
 The main reason is that **this is how we’re building the CSS for this site** and it’ll be really helpful to be aware of the methodology behind it.
 

--- a/docs/lesson/27.md
+++ b/docs/lesson/27.md
@@ -6,7 +6,7 @@ We’re getting very close to the end now and our site is starting to look reall
 
 ## Creating a page header block
 
-This block is almost hilariously tiny. Because of our CSS methodology—[CUBE CSS](https://piccalil.lihttps://piccalil.li/blog/cube-css)—we only have to add 3 lines of CSS here.
+This block is almost hilariously tiny. Because of our CSS methodology—[CUBE CSS](https://piccalil.li/cube-css/)—we only have to add 3 lines of CSS here.
 
 Create a new file in your `blocks` folder called `_page-header.scss` and add the following to it:
 

--- a/docs/lesson/28.md
+++ b/docs/lesson/28.md
@@ -51,7 +51,7 @@ Create a new file in your `blocks` folder called `_people.scss` and add the foll
 }
 ```
 
-This is [CUBE CSS](https://piccalil.lihttps://piccalil.li/blog/cube-css) in a nutshell. We have a utility that does one job and does it well, and a compositional block creates some context for it.
+This is [CUBE CSS](https://piccalil.li/cube-css/) in a nutshell. We have a utility that does one job and does it well, and a compositional block creates some context for it.
 
 Let’s add that to our critical CSS. Open up `eleventy-from-scratch/src/scss/critical.scss` and on **line 83**, add the following, with the other block `@import` statements:
 


### PR DESCRIPTION
Apologies, but in #20 I was too eager to contribute I didn't consider that the issue could be repeated in later lessons. I found the same broken link in lesson 22, 27 and 28.

```diff
- https://piccalil.lihttps//piccalil.li/blog/cube-css/
+https://piccalil.li/blog/cube-css/
```

Rather interestingly lesson 26 refers to the correct version. 