### PR TITLE
replaced old filter "slug" with 11ty 1.0 standard "slugify"

### DIFF
--- a/docs/lesson/11.md
+++ b/docs/lesson/11.md
@@ -297,7 +297,7 @@ pagination:
   size: 1
   alias: tag
   filter: ['all', 'nav', 'blog', 'work', 'featuredWork', 'people', 'rss']
-permalink: '/tag/{{ tag | slug }}/'
+permalink: '/tag/{{ tag | slugify }}/'
 ---
 ```
 

--- a/docs/lesson/12.md
+++ b/docs/lesson/12.md
@@ -165,7 +165,7 @@ Create a new file in your `posts` folder called `posts.json` and add the followi
 
 This is called a directory data file. Inside it, we’re telling all items added to `posts` that they should use the `post.html` layout **unless they specify a different layout in their Front Matter**.
 
-The second thing we’re doing is setting a permalink. Eleventy, by default, will use the filename and its directory to create a permalink. This means that, without our current setting, a post with a file name of `my-lovely-post.md` would have a permalink of `/posts/my-lovely-post/index.html`. We want all of our posts to live in the blog section though, so what we’re doing in the value for `permalink` is setting `/blog` as the root and then slugifying the post’s title.
+The second thing we’re doing is setting a permalink. Eleventy, by default, will use the filename and its directory to create a permalink. This means that, without our current setting, a post with a file name of `my-lovely-post.md` would have a permalink of `/posts/my-lovely-post/index.html`. We want all of our posts to live in the blog section though, so what we’re doing in the value for `permalink` is setting `/blog` as the root and then creating a slug from the post’s title.
 
 Now, if you open your browser at <http://localhost:8080/blog/laws-of-ux/> it should look like this:
 

--- a/docs/lesson/12.md
+++ b/docs/lesson/12.md
@@ -24,7 +24,7 @@ Create a new file in your `layouts` folder called `post.html` and add the follow
     <ul class="tags-list" aria-describedby="tags-desc">
       {% for tag in tags %}
         <li>
-          <a href="/tag/{{ tag | slug }}/">#{{ tag | title | replace(' ', '') }}</a>
+          <a href="/tag/{{ tag | slugify }}/">#{{ tag | title | replace(' ', '') }}</a>
         </li>
       {% endfor %}
     </ul>
@@ -63,7 +63,7 @@ What this does is capture everything between `{% set %}` and `{% endset %}` and 
 
 In the context of `pageHeaderSummary`, we’ve rendered some markup in our `{% set %}` block. This is because with a blog post, we want a bit of extra data in the page header, like posted date and tags.
 
-The tags themselves are pretty straightforward: we take the `tags` from our Front Matter (remember, they’re an array) and we loop each one. Inside each iteration of the loop, we generate a list item with a link to that tag. Using the [replace filter from Nunjucks](https://mozilla.github.io/nunjucks/templating.html#replace), we create a Twitter-style hashtag as the label of the link. Using the [Eleventy slug filter](https://www.11ty.dev/docs/filters/slug/), we create a URL friendly version of the tag. This means that `Design Thinking` becomes `design-thinking`.
+The tags themselves are pretty straightforward: we take the `tags` from our Front Matter (remember, they’re an array) and we loop each one. Inside each iteration of the loop, we generate a list item with a link to that tag. Using the [replace filter from Nunjucks](https://mozilla.github.io/nunjucks/templating.html#replace), we create a Twitter-style hashtag as the label of the link. Using the [Eleventy slugify filter](https://www.11ty.dev/docs/filters/slugify/), we create a URL friendly version of the tag. This means that `Design Thinking` becomes `design-thinking`.
 
 ::: tip
 
@@ -159,13 +159,13 @@ Create a new file in your `posts` folder called `posts.json` and add the followi
 ```json
 {
   "layout": "layouts/post.html",
-  "permalink": "/blog/{{ title | slug }}/index.html"
+  "permalink": "/blog/{{ title | slugify }}/index.html"
 }
 ```
 
 This is called a directory data file. Inside it, we’re telling all items added to `posts` that they should use the `post.html` layout **unless they specify a different layout in their Front Matter**.
 
-The second thing we’re doing is setting a permalink. Eleventy, by default, will use the filename and its directory to create a permalink. This means that, without our current setting, a post with a file name of `my-lovely-post.md` would have a permalink of `/posts/my-lovely-post/index.html`. We want all of our posts to live in the blog section though, so what we’re doing in the value for `permalink` is setting `/blog` as the root and then creating a slug from the post’s title.
+The second thing we’re doing is setting a permalink. Eleventy, by default, will use the filename and its directory to create a permalink. This means that, without our current setting, a post with a file name of `my-lovely-post.md` would have a permalink of `/posts/my-lovely-post/index.html`. We want all of our posts to live in the blog section though, so what we’re doing in the value for `permalink` is setting `/blog` as the root and then slugifying the post’s title.
 
 Now, if you open your browser at <http://localhost:8080/blog/laws-of-ux/> it should look like this:
 


### PR DESCRIPTION
Eleventy 1.0.0 replaced the `slug` universal filter with `slugify`.

This PR updates the course, including URLs & documentation.