### PR TITLE
Pin Version 7.1.0 of gulp-imagemin, to keep 11ty compatibility.

### DIFF
--- a/docs/lesson/21.md
+++ b/docs/lesson/21.md
@@ -46,8 +46,10 @@ Hopefully at this point, you’re starting to see a pattern with these Gulp task
 Right, we need to wire this one up, too. But before that, let’s install our dependency. Open up your terminal in `eleventy-from-scratch` and run the following command:
 
 ```bash
-npm install gulp-imagemin
+npm install gulp-imagemin@7.1.0 --save-exact
 ```
+
+The bits after the @ sign are `npm` options to "pin" version 7 of `gulp-imagemin`, which is the latest version that's compatible with Eleventy.
 
 ## Adding the task to our gulpfile
 


### PR DESCRIPTION
Change to the `npm` command in lesson 21, so gulp works as intended instead of exiting with an error.

Closes [#24].